### PR TITLE
build: update to release version of theme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydata-sphinx-theme==0.12.0rc1
+pydata-sphinx-theme==0.12.0
 sphinx==5.3.0
 sphinx-copybutton==0.5.0
 sphinx_rtd_theme==1.1.1


### PR DESCRIPTION
Bump to actual release version instead of release candidate. This seemed to work fine for me so we should go with the official release.